### PR TITLE
Fix several OWs not showing up properly

### DIFF
--- a/spritesheet_rules.mk
+++ b/spritesheet_rules.mk
@@ -542,12 +542,6 @@ $(OBJEVENTGFXDIR)/people/swimmer_f_land.4bpp: %.4bpp: %.png
 $(OBJEVENTGFXDIR)/people/swimmer_m_land.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
 
-$(OBJEVENTGFXDIR)/people/cycling_triathlete_f.4bpp: %.4bpp: %.png
-	$(GFX) $< $@ -mwidth 4 -mheight 4
-
-$(OBJEVENTGFXDIR)/people/cycling_triathlete_m.4bpp: %.4bpp: %.png
-	$(GFX) $< $@ -mwidth 4 -mheight 4
-
 $(OBJEVENTGFXDIR)/pokemon_old/azumarill.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 2
 


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
Several overworld sprites were showing up appearing bugged since they weren't defined correctly in spritesheet rules, namely Police Officer, Balding Man, Little Boy, Scientist M/F, and others 

## Discord Contact
soupercell
