### PR TITLE
Trainers unused in HnS scripts comments

### DIFF
--- a/include/constants/opponents.h
+++ b/include/constants/opponents.h
@@ -3,870 +3,870 @@
 
 #include "constants/battle_partner.h"
 
-#define TRAINER_NONE                          0
-#define TRAINER_SAWYER_1                      1
-#define TRAINER_SAYO          2
-#define TRAINER_SCOTT          3
-#define TRAINER_SEAN          4
-#define TRAINER_SETH          5
-#define TRAINER_TROY       6
-#define TRAINER_TULLY       7
-#define TRAINER_TYLER       8
-#define TRAINER_ROD                   9
-#define TRAINER_TONY        10
-#define TRAINER_MARCEL                       11
-#define TRAINER_ARNOLD                      12
-#define TRAINER_ED                           13
-#define TRAINER_VALERIE      14
-#define TRAINER_JOYCE                       15
-#define TRAINER_TREVOR         16
-#define TRAINER_ZEKE         17
-#define TRAINER_ZUKI         18
-#define TRAINER_FALKNER_1         19
-#define TRAINER_TODD               20
-#define TRAINER_TOM               21
-#define TRAINER_VERONICA         22
-#define TRAINER_THERESA              23
-#define TRAINER_TIM              24
-#define TRAINER_TIMOTHY              25
-#define TRAINER_FALKNER_2         26
-#define TRAINER_SID         27
-#define TRAINER_STANLY         28
-#define TRAINER_REBECCA                     29
-#define TRAINER_MATT                         30
-#define TRAINER_ZANDER                       31
-#define TRAINER_DEVIN     32
-#define TRAINER_GRANT       33
-#define TRAINER_CASSIE                       34
-#define TRAINER_LEAH                         35
-#define TRAINER_JEFFREY                        36
-#define TRAINER_GRUNT_33                       37
-#define TRAINER_NORMAN                        38
-#define TRAINER_VIOLET                       39
-#define TRAINER_ROSE_2                       40
-#define TRAINER_ROSE_3                       41
-#define TRAINER_ROSE_4                       42
-#define TRAINER_ROSE_5                       43
+#define TRAINER_NONE                       0
+#define TRAINER_SAWYER_1                   1 // UNUSED
+#define TRAINER_SAYO                       2
+#define TRAINER_SCOTT                      3
+#define TRAINER_SEAN                       4
+#define TRAINER_SETH                       5
+#define TRAINER_TROY                       6
+#define TRAINER_TULLY                      7
+#define TRAINER_TYLER                      8 // UNUSED
+#define TRAINER_ROD                        9
+#define TRAINER_TONY                       10 // UNUSED
+#define TRAINER_MARCEL                     11 // UNUSED
+#define TRAINER_ARNOLD                     12
+#define TRAINER_ED                         13
+#define TRAINER_VALERIE                    14
+#define TRAINER_JOYCE                      15
+#define TRAINER_TREVOR                     16
+#define TRAINER_ZEKE                       17
+#define TRAINER_ZUKI                       18
+#define TRAINER_FALKNER_1                  19
+#define TRAINER_TODD                       20
+#define TRAINER_TOM                        21
+#define TRAINER_VERONICA                   22 // UNUSED
+#define TRAINER_THERESA                    23 // UNUSED
+#define TRAINER_TIM                        24
+#define TRAINER_TIMOTHY                    25
+#define TRAINER_FALKNER_2                  26
+#define TRAINER_SID                        27
+#define TRAINER_STANLY                     28
+#define TRAINER_REBECCA                    29
+#define TRAINER_MATT                       30 // UNUSED
+#define TRAINER_ZANDER                     31 // UNUSED
+#define TRAINER_DEVIN                      32
+#define TRAINER_GRANT                      33
+#define TRAINER_CASSIE                     34
+#define TRAINER_LEAH                       35 // UNUSED
+#define TRAINER_JEFFREY                    36
+#define TRAINER_GRUNT_33                   37
+#define TRAINER_NORMAN                     38
+#define TRAINER_VIOLET                     39 // UNUSED
+#define TRAINER_ROSE_2                     40 // UNUSED
+#define TRAINER_ROSE_3                     41 // UNUSED
+#define TRAINER_ROSE_4                     42 // UNUSED
+#define TRAINER_ROSE_5                     43 // UNUSED
 #define TRAINER_KRISE                      44
-#define TRAINER_GRUNT_16                         45
-#define TRAINER_RAYMOND                       46
-#define TRAINER_KUNI                      47
-#define TRAINER_KYLE                      48
-#define TRAINER_LAO                      49
-#define TRAINER_LEA_AND_PIA                      50
-#define TRAINER_REENA               51
-#define TRAINER_REX               52
-#define TRAINER_RICH               53
-#define TRAINER_RICKY               54
-#define TRAINER_ROB               55
-#define TRAINER_ROBERT               56
-#define TRAINER_LOLA_1                       57
-#define TRAINER_CODY                      58
-#define TRAINER_GWEN                         59
-#define TRAINER_LOLA_2                       60
-#define TRAINER_LOLA_3                       61
-#define TRAINER_LOLA_4                       62
-#define TRAINER_LOLA_5                       63
-#define TRAINER_RICKY_1                      64
-#define TRAINER_SIMON                        65
-#define TRAINER_CHARLIE                      66
-#define TRAINER_RICKY_2                      67
-#define TRAINER_RICKY_3                      68
-#define TRAINER_RICKY_4                      69
-#define TRAINER_RICKY_5                      70
-#define TRAINER_RANDALL                      71
-#define TRAINER_PARKER                       72
-#define TRAINER_GEORGE                       73
-#define TRAINER_BERKE                        74
-#define TRAINER_ELAINE                      75
-#define TRAINER_VINCENT                      76
-#define TRAINER_LEROY                        77
-#define TRAINER_WILTON_1                     78
-#define TRAINER_EDGAR                        79
-#define TRAINER_ALBERT                       80
-#define TRAINER_SAMUEL                       81
-#define TRAINER_VITO                         82
-#define TRAINER_OWEN                         83
-#define TRAINER_WILTON_2                     84
-#define TRAINER_WILTON_3                     85
-#define TRAINER_WILTON_4                     86
-#define TRAINER_WILTON_5                     87
-#define TRAINER_WARREN                       88
-#define TRAINER_MARY                         89
-#define TRAINER_BARNEY                       90
-#define TRAINER_JODY                         91
-#define TRAINER_WENDY                        92
-#define TRAINER_KEIRA                        93
-#define TRAINER_EMMA                     94
-#define TRAINER_GIOVANNI                     95
-#define TRAINER_HOPE                         96
-#define TRAINER_SHANNON                      97
-#define TRAINER_MICHELLE                     98
-#define TRAINER_CAROLINE                     99
-#define TRAINER_JULIE                       100
-#define TRAINER_ERICK                    101
-#define TRAINER_ERIK                    102
-#define TRAINER_ERIN                    103
-#define TRAINER_ERNEST                    104
-#define TRAINER_PATRICIA                    105
-#define TRAINER_KINDRA                      106
-#define TRAINER_TAMMY                       107
-#define TRAINER_VALERIE_1                   108
-#define TRAINER_TASHA                       109
-#define TRAINER_VALERIE_2                   110
-#define TRAINER_VALERIE_3                   111
-#define TRAINER_VALERIE_4                   112
-#define TRAINER_VALERIE_5                   113
-#define TRAINER_GRUNT_18                     114
-#define TRAINER_KIPP                      115
-#define TRAINER_WAI        116
-#define TRAINER_GRUNT_19                     117
-#define TRAINER_ELLEN                     118
-#define TRAINER_NAOMI                       119
-#define TRAINER_GRUNT_20                     120
-#define TRAINER_GRUNT_21                     121
-#define TRAINER_GRUNT_22                     122
-#define TRAINER_GRUNT_23                     123
-#define TRAINER_MELISSA                     124
-#define TRAINER_SHEILA                      125
-#define TRAINER_SHIRLEY                     126
+#define TRAINER_GRUNT_16                   45
+#define TRAINER_RAYMOND                    46
+#define TRAINER_KUNI                       47
+#define TRAINER_KYLE                       48
+#define TRAINER_LAO                        49
+#define TRAINER_LEA_AND_PIA                50
+#define TRAINER_REENA                      51
+#define TRAINER_REX                        52
+#define TRAINER_RICH                       53
+#define TRAINER_RICKY                      54
+#define TRAINER_ROB                        55
+#define TRAINER_ROBERT                     56
+#define TRAINER_LOLA_1                     57 // UNUSED
+#define TRAINER_CODY                       58
+#define TRAINER_GWEN                       59
+#define TRAINER_LOLA_2                     60 // UNUSED
+#define TRAINER_LOLA_3                     61 // UNUSED
+#define TRAINER_LOLA_4                     62 // UNUSED
+#define TRAINER_LOLA_5                     63 // UNUSED
+#define TRAINER_RICKY_1                    64 // UNUSED
+#define TRAINER_SIMON                      65
+#define TRAINER_CHARLIE                    66
+#define TRAINER_RICKY_2                    67 // UNUSED
+#define TRAINER_RICKY_3                    68 // UNUSED
+#define TRAINER_RICKY_4                    69 // UNUSED
+#define TRAINER_RICKY_5                    70 // UNUSED
+#define TRAINER_RANDALL                    71
+#define TRAINER_PARKER                     72
+#define TRAINER_GEORGE                     73
+#define TRAINER_BERKE                      74
+#define TRAINER_ELAINE                     75
+#define TRAINER_VINCENT                    76
+#define TRAINER_LEROY                      77 // UNUSED
+#define TRAINER_WILTON_1                   78 // UNUSED
+#define TRAINER_EDGAR                      79
+#define TRAINER_ALBERT                     80
+#define TRAINER_SAMUEL                     81
+#define TRAINER_VITO                       82 // UNUSED
+#define TRAINER_OWEN                       83
+#define TRAINER_WILTON_2                   84 // UNUSED
+#define TRAINER_WILTON_3                   85 // UNUSED
+#define TRAINER_WILTON_4                   86 // UNUSED
+#define TRAINER_WILTON_5                   87 // UNUSED
+#define TRAINER_WARREN                     88
+#define TRAINER_MARY                       89 // UNUSED
+#define TRAINER_BARNEY                     90
+#define TRAINER_JODY                       91 // UNUSED
+#define TRAINER_WENDY                      92
+#define TRAINER_KEIRA                      93 // UNUSED
+#define TRAINER_EMMA                       94
+#define TRAINER_GIOVANNI                   95
+#define TRAINER_HOPE                       96
+#define TRAINER_SHANNON                    97
+#define TRAINER_MICHELLE                   98
+#define TRAINER_CAROLINE                   99 // UNUSED
+#define TRAINER_JULIE                      100 // UNUSED
+#define TRAINER_ERICK                      101 // UNUSED
+#define TRAINER_ERIK                       102
+#define TRAINER_ERIN                       103
+#define TRAINER_ERNEST                     104
+#define TRAINER_PATRICIA                   105 // UNUSED
+#define TRAINER_KINDRA                     106 // UNUSED
+#define TRAINER_TAMMY                      107 // UNUSED
+#define TRAINER_VALERIE_1                  108 // UNUSED
+#define TRAINER_TASHA                      109 // UNUSED
+#define TRAINER_VALERIE_2                  110 // UNUSED
+#define TRAINER_VALERIE_3                  111 // UNUSED
+#define TRAINER_VALERIE_4                  112 // UNUSED
+#define TRAINER_VALERIE_5                  113 // UNUSED
+#define TRAINER_GRUNT_18                   114
+#define TRAINER_KIPP                       115
+#define TRAINER_WAI                        116
+#define TRAINER_GRUNT_19                   117
+#define TRAINER_ELLEN                      118
+#define TRAINER_NAOMI                      119 // UNUSED
+#define TRAINER_GRUNT_20                   120
+#define TRAINER_GRUNT_21                   121
+#define TRAINER_GRUNT_22                   122
+#define TRAINER_GRUNT_23                   123
+#define TRAINER_MELISSA                    124 // UNUSED
+#define TRAINER_SHEILA                     125 // UNUSED
+#define TRAINER_SHIRLEY                    126
 #define TRAINER_ARIANA_1                   127
-#define TRAINER_CONNIE                      128
-#define TRAINER_BRIDGET                     129
-#define TRAINER_OLIVIA                      130
-#define TRAINER_TIFFANY                     131
+#define TRAINER_CONNIE                     128
+#define TRAINER_BRIDGET                    129
+#define TRAINER_OLIVIA                     130
+#define TRAINER_TIFFANY                    131
 #define TRAINER_ARIANA_2                   132
-#define TRAINER_JESSICA_3                   133
-#define TRAINER_JESSICA_4                   134
-#define TRAINER_JESSICA_5                   135
-#define TRAINER_WINSTON_1                   136
-#define TRAINER_MOLLIE                      137
-#define TRAINER_GARRET                      138
-#define TRAINER_WINSTON_2                   139
-#define TRAINER_WINSTON_3                   140
-#define TRAINER_WINSTON_4                   141
-#define TRAINER_WINSTON_5                   142
-#define TRAINER_STEVE_1                     143
-#define TRAINER_THALIA_1                    144
-#define TRAINER_MARK                        145
-#define TRAINER_TERU          146
-#define TRAINER_STEVE_2                     147
-#define TRAINER_STEVE_3                     148
-#define TRAINER_STEVE_4                     149
-#define TRAINER_STEVE_5                     150
-#define TRAINER_LUIS                        151
-#define TRAINER_KENNY                     152
-#define TRAINER_DOUGLAS                     153
-#define TRAINER_JO_AND_ZOE                      154
-#define TRAINER_TONY_1                      155
-#define TRAINER_JEROME                      156
-#define TRAINER_MATTHEW                     157
-#define TRAINER_DAVID                       158
-#define TRAINER_SPENCER                     159
-#define TRAINER_ROLAND                      160
-#define TRAINER_NOLEN                       161
-#define TRAINER_STAN                        162
-#define TRAINER_BARRY                       163
-#define TRAINER_DEAN                        164
-#define TRAINER_RODNEY                      165
-#define TRAINER_RICHARD                     166
-#define TRAINER_HERMAN                      167
-#define TRAINER_SANTIAGO                    168
-#define TRAINER_GILBERT                     169
-#define TRAINER_FRANKLIN                    170
-#define TRAINER_KEVIN                       171
-#define TRAINER_JACK                        172
-#define TRAINER_DUDLEY                      173
-#define TRAINER_CHAD                        174
-#define TRAINER_TONY_2                      175
-#define TRAINER_TONY_3                      176
-#define TRAINER_TONY_4                      177
-#define TRAINER_TONY_5                      178
-#define TRAINER_TAKAO                       179
-#define TRAINER_JASMINE_1_3                     180
-#define TRAINER_KIYO                        181
-#define TRAINER_KOICHI                      182
-#define TRAINER_NOB_1                       183
-#define TRAINER_NOB_2                       184
-#define TRAINER_NOB_3                       185
-#define TRAINER_NOB_4                       186
-#define TRAINER_NOB_5                       187
-#define TRAINER_YUJI                        188
-#define TRAINER_JED                     189
-#define TRAINER_CINDY                     190
-#define TRAINER_KIRK                        191
-#define TRAINER_STEPHEN        192
-#define TRAINER_STEVE        193
-#define TRAINER_SHAWN                       194
-#define TRAINER_NORTON                  195
-#define TRAINER_JENN                    196
-#define TRAINER_JEREMY                    197
-#define TRAINER_JERRY                    198
-#define TRAINER_JESSICA                    199
-#define TRAINER_JILL                    200
-#define TRAINER_COLE                        201
-#define TRAINER_JEFF                        202
-#define TRAINER_COREY                        203
-#define TRAINER_KOGA_2                        204
-#define TRAINER_KEEGAN                      205
-#define TRAINER_DARYL                    206
-#define TRAINER_DAVE                    207
-#define TRAINER_DAWN                    208
-#define TRAINER_DENIS                    209
-#define TRAINER_DIANA                    210
-#define TRAINER_KOJI                        211
-#define TRAINER_DANIEL                        212
-#define TRAINER_LARRY                       213
-#define TRAINER_SHANE                       214
-#define TRAINER_JUSTIN                      215
-#define TRAINER_NAOKO                     216
-#define TRAINER_COLETTE                      217
-#define TRAINER_TRAVIS                      218
+#define TRAINER_JESSICA_3                  133 // UNUSED
+#define TRAINER_JESSICA_4                  134 // UNUSED
+#define TRAINER_JESSICA_5                  135 // UNUSED
+#define TRAINER_WINSTON_1                  136 // UNUSED
+#define TRAINER_MOLLIE                     137 // UNUSED
+#define TRAINER_GARRET                     138 // UNUSED
+#define TRAINER_WINSTON_2                  139 // UNUSED
+#define TRAINER_WINSTON_3                  140 // UNUSED
+#define TRAINER_WINSTON_4                  141 // UNUSED
+#define TRAINER_WINSTON_5                  142 // UNUSED
+#define TRAINER_STEVE_1                    143 // UNUSED
+#define TRAINER_THALIA_1                   144 // UNUSED
+#define TRAINER_MARK                       145
+#define TRAINER_TERU                       146
+#define TRAINER_STEVE_2                    147 // UNUSED
+#define TRAINER_STEVE_3                    148 // UNUSED
+#define TRAINER_STEVE_4                    149 // UNUSED
+#define TRAINER_STEVE_5                    150 // UNUSED
+#define TRAINER_LUIS                       151 // UNUSED
+#define TRAINER_KENNY                      152
+#define TRAINER_DOUGLAS                    153
+#define TRAINER_JO_AND_ZOE                 154
+#define TRAINER_TONY_1                     155 // UNUSED
+#define TRAINER_JEROME                     156
+#define TRAINER_MATTHEW                    157 // UNUSED
+#define TRAINER_DAVID                      158 // UNUSED
+#define TRAINER_SPENCER                    159
+#define TRAINER_ROLAND                     160
+#define TRAINER_NOLEN                      161 // UNUSED
+#define TRAINER_STAN                       162
+#define TRAINER_BARRY                      163
+#define TRAINER_DEAN                       164
+#define TRAINER_RODNEY                     165 // UNUSED
+#define TRAINER_RICHARD                    166
+#define TRAINER_HERMAN                     167
+#define TRAINER_SANTIAGO                   168 // UNUSED
+#define TRAINER_GILBERT                    169
+#define TRAINER_FRANKLIN                   170
+#define TRAINER_KEVIN                      171
+#define TRAINER_JACK                       172
+#define TRAINER_DUDLEY                     173
+#define TRAINER_CHAD                       174
+#define TRAINER_TONY_2                     175 // UNUSED
+#define TRAINER_TONY_3                     176 // UNUSED
+#define TRAINER_TONY_4                     177 // UNUSED
+#define TRAINER_TONY_5                     178 // UNUSED
+#define TRAINER_TAKAO                      179 // UNUSED
+#define TRAINER_JASMINE_1_3                180
+#define TRAINER_KIYO                       181
+#define TRAINER_KOICHI                     182 // UNUSED
+#define TRAINER_NOB_1                      183 // UNUSED
+#define TRAINER_NOB_2                      184 // UNUSED
+#define TRAINER_NOB_3                      185 // UNUSED
+#define TRAINER_NOB_4                      186 // UNUSED
+#define TRAINER_NOB_5                      187 // UNUSED
+#define TRAINER_YUJI                       188 // UNUSED
+#define TRAINER_JED                        189
+#define TRAINER_CINDY                      190
+#define TRAINER_KIRK                       191
+#define TRAINER_STEPHEN                    192
+#define TRAINER_STEVE                      193 // UNUSED
+#define TRAINER_SHAWN                      194 // UNUSED
+#define TRAINER_NORTON                     195 // UNUSED
+#define TRAINER_JENN                       196
+#define TRAINER_JEREMY                     197 // UNUSED
+#define TRAINER_JERRY                      198
+#define TRAINER_JESSICA                    199 // UNUSED
+#define TRAINER_JILL                       200 // UNUSED
+#define TRAINER_COLE                       201 // UNUSED
+#define TRAINER_JEFF                       202
+#define TRAINER_COREY                      203
+#define TRAINER_KOGA_2                     204
+#define TRAINER_KEEGAN                     205 // UNUSED
+#define TRAINER_DARYL                      206 // UNUSED
+#define TRAINER_DAVE                       207 // UNUSED
+#define TRAINER_DAWN                       208
+#define TRAINER_DENIS                      209
+#define TRAINER_DIANA                      210
+#define TRAINER_KOJI                       211 // UNUSED
+#define TRAINER_DANIEL                     212
+#define TRAINER_LARRY                      213
+#define TRAINER_SHANE                      214
+#define TRAINER_JUSTIN                     215
+#define TRAINER_NAOKO                      216
+#define TRAINER_COLETTE                    217
+#define TRAINER_TRAVIS                     218 // UNUSED
 #define TRAINER_NATHAN                     219
-#define TRAINER_NEAL                     220
-#define TRAINER_NICK                     221
-#define TRAINER_NICO                     222
-#define TRAINER_BRENT                       223
-#define TRAINER_DONALD                      224
-#define TRAINER_TAYLOR                      225
-#define TRAINER_RIVAL_TOTODILE_5                   226
-#define TRAINER_DEREK                       227
-#define TRAINER_RIVAL_TOTODILE_6                   228
-#define TRAINER_RIVAL_TOTODILE_7                   229
-#define TRAINER_RED_1                   230
-#define TRAINER_RED_2                   231
-#define TRAINER_EDWARD                      232
-#define TRAINER_PRESTON                     233
-#define TRAINER_VIRGIL                      234
-#define TRAINER_BLAKE                       235
-#define TRAINER_WILLIAM                     236
-#define TRAINER_JOSHUA                      237
-#define TRAINER_GAVEN                   238
-#define TRAINER_GINA                   239
-#define TRAINER_GLENN                   240
-#define TRAINER_GORDON                   241
-#define TRAINER_GREGG                   242
-#define TRAINER_JACLYN                      243
-#define TRAINER_PRYCE_2                      244
-#define TRAINER_SAMANTHA                    245
-#define TRAINER_MAURA                       246
-#define TRAINER_KAYLA                       247
-#define TRAINER_BENJAMIN                      248
-#define TRAINER_LANCE_1                     249
-#define TRAINER_LANCE_2                     250
-#define TRAINER_RIVAL_CHIKORITA_1                     251
-#define TRAINER_RIVAL_CHIKORITA_2                     252
-#define TRAINER_RIVAL_CHIKORITA_3                     253
-#define TRAINER_WALTER_1                    254
-#define TRAINER_MICAH                       255
-#define TRAINER_THOMAS                      256
-#define TRAINER_WALTER_2                    257
-#define TRAINER_WALTER_3                    258
-#define TRAINER_WALTER_4                    259
-#define TRAINER_WALTER_5                    260
-#define TRAINER_SIDNEY                      261
-#define TRAINER_PHOEBE                      262
-#define TRAINER_GLACIA                      263
-#define TRAINER_KIP                       264
-#define TRAINER_ROXANNE_1                   265
-#define TRAINER_DICK                    266
-#define TRAINER_WATTSON_1                   267
-#define TRAINER_PING                  268
-#define TRAINER_NORMAN_1                    269
-#define TRAINER_WINONA_1                    270
-#define TRAINER_TATE_AND_LIZA_1             271
-#define TRAINER_JUAN_1                      272
-#define TRAINER_ARCHER_1                     273
-#define TRAINER_TED                         274
-#define TRAINER_PAUL                        275
-#define TRAINER_ARCHER_4                     276
-#define TRAINER_ARCHER_5                     277
-#define TRAINER_PETREL_2                     278
-#define TRAINER_PROTON_2                     279
-#define TRAINER_UNUSEDNAME_2                     280
-#define TRAINER_GEORGIA                     281
-#define TRAINER_BLUE_2                     282
-#define TRAINER_KAREN_3                     283
-#define TRAINER_KAREN_4                     284
-#define TRAINER_KAREN_5                     285
-#define TRAINER_KATE_AND_JOY                286
-#define TRAINER_ANNA_AND_MEG_1              287
-#define TRAINER_ANNA_AND_MEG_2              288
-#define TRAINER_ANNA_AND_MEG_3              289
-#define TRAINER_ANNA_AND_MEG_4              290
-#define TRAINER_ANNA_AND_MEG_5              291
-#define TRAINER_VICTOR                      292
-#define TRAINER_MIGUEL_1                    293
-#define TRAINER_GRUNT_26                      294
-#define TRAINER_MIGUEL_2                    295
-#define TRAINER_MIGUEL_3                    296
-#define TRAINER_MIGUEL_4                    297
-#define TRAINER_MIGUEL_5                    298
-#define TRAINER_VICTORIA                    299
-#define TRAINER_VANESSA                     300
-#define TRAINER_BETHANY                     301
+#define TRAINER_NEAL                       220
+#define TRAINER_NICK                       221
+#define TRAINER_NICO                       222
+#define TRAINER_BRENT                      223
+#define TRAINER_DONALD                     224
+#define TRAINER_TAYLOR                     225 // UNUSED
+#define TRAINER_RIVAL_TOTODILE_5           226
+#define TRAINER_DEREK                      227
+#define TRAINER_RIVAL_TOTODILE_6           228
+#define TRAINER_RIVAL_TOTODILE_7           229
+#define TRAINER_RED_1                      230 // UNUSED
+#define TRAINER_RED_2                      231
+#define TRAINER_EDWARD                     232
+#define TRAINER_PRESTON                    233
+#define TRAINER_VIRGIL                     234 // UNUSED
+#define TRAINER_BLAKE                      235
+#define TRAINER_WILLIAM                    236
+#define TRAINER_JOSHUA                     237
+#define TRAINER_GAVEN                      238
+#define TRAINER_GINA                       239
+#define TRAINER_GLENN                      240
+#define TRAINER_GORDON                     241
+#define TRAINER_GREGG                      242 // UNUSED
+#define TRAINER_JACLYN                     243 // UNUSED
+#define TRAINER_PRYCE_2                    244
+#define TRAINER_SAMANTHA                   245
+#define TRAINER_MAURA                      246 // UNUSED
+#define TRAINER_KAYLA                      247 // UNUSED
+#define TRAINER_BENJAMIN                   248
+#define TRAINER_LANCE_1                    249
+#define TRAINER_LANCE_2                    250
+#define TRAINER_RIVAL_CHIKORITA_1          251
+#define TRAINER_RIVAL_CHIKORITA_2          252
+#define TRAINER_RIVAL_CHIKORITA_3          253
+#define TRAINER_WALTER_1                   254 // UNUSED
+#define TRAINER_MICAH                      255 // UNUSED
+#define TRAINER_THOMAS                     256 // UNUSED
+#define TRAINER_WALTER_2                   257 // UNUSED
+#define TRAINER_WALTER_3                   258 // UNUSED
+#define TRAINER_WALTER_4                   259 // UNUSED
+#define TRAINER_WALTER_5                   260 // UNUSED
+#define TRAINER_SIDNEY                     261
+#define TRAINER_PHOEBE                     262 // UNUSED
+#define TRAINER_GLACIA                     263 // UNUSED
+#define TRAINER_KIP                        264 // UNUSED
+#define TRAINER_ROXANNE_1                  265 // UNUSED
+#define TRAINER_DICK                       266 // UNUSED
+#define TRAINER_WATTSON_1                  267 // UNUSED
+#define TRAINER_PING                       268
+#define TRAINER_NORMAN_1                   269 // UNUSED
+#define TRAINER_WINONA_1                   270 // UNUSED
+#define TRAINER_TATE_AND_LIZA_1            271 // UNUSED
+#define TRAINER_JUAN_1                     272 // UNUSED
+#define TRAINER_ARCHER_1                   273 // UNUSED
+#define TRAINER_TED                        274
+#define TRAINER_PAUL                       275
+#define TRAINER_ARCHER_4                   276 // UNUSED
+#define TRAINER_ARCHER_5                   277 // UNUSED
+#define TRAINER_PETREL_2                   278
+#define TRAINER_PROTON_2                   279
+#define TRAINER_UNUSEDNAME_2               280 // UNUSED
+#define TRAINER_GEORGIA                    281 // UNUSED
+#define TRAINER_BLUE_2                     282 // UNUSED
+#define TRAINER_KAREN_3                    283 // UNUSED
+#define TRAINER_KAREN_4                    284 // UNUSED
+#define TRAINER_KAREN_5                    285 // UNUSED
+#define TRAINER_KATE_AND_JOY               286 // UNUSED
+#define TRAINER_ANNA_AND_MEG_1             287 // UNUSED
+#define TRAINER_ANNA_AND_MEG_2             288 // UNUSED
+#define TRAINER_ANNA_AND_MEG_3             289 // UNUSED
+#define TRAINER_ANNA_AND_MEG_4             290 // UNUSED
+#define TRAINER_ANNA_AND_MEG_5             291 // UNUSED
+#define TRAINER_VICTOR                     292 // UNUSED
+#define TRAINER_MIGUEL_1                   293 // UNUSED
+#define TRAINER_GRUNT_26                   294
+#define TRAINER_MIGUEL_2                   295 // UNUSED
+#define TRAINER_MIGUEL_3                   296 // UNUSED
+#define TRAINER_MIGUEL_4                   297 // UNUSED
+#define TRAINER_MIGUEL_5                   298 // UNUSED
+#define TRAINER_VICTORIA                   299
+#define TRAINER_VANESSA                    300 // UNUSED
+#define TRAINER_BETHANY                    301 // UNUSED
 #define TRAINER_LTSURGE                    302
-#define TRAINER_ERIKA                    303
+#define TRAINER_ERIKA                      303
 #define TRAINER_SABRINA                    304
-#define TRAINER_JANINE                    305
-#define TRAINER_BLAINE                    306
-#define TRAINER_TIMOTHY_1                   307
-#define TRAINER_TIMOTHY_2                   308
-#define TRAINER_TIMOTHY_3                   309
-#define TRAINER_TIMOTHY_4                   310
-#define TRAINER_TIMOTHY_5                   311
-#define TRAINER_VICKY                       312
-#define TRAINER_SHELBY_1                    313
-#define TRAINER_SHELBY_2                    314
-#define TRAINER_SHELBY_3                    315
-#define TRAINER_SHELBY_4                    316
-#define TRAINER_SHELBY_5                    317
-#define TRAINER_EUGENE                    318
-#define TRAINER_BILLY                       319
-#define TRAINER_JOSH                        320
-#define TRAINER_TOMMY                       321
-#define TRAINER_JOEY                        322
-#define TRAINER_BEN                         323
-#define TRAINER_QUINCY                      324
-#define TRAINER_KATELYNN                    325
-#define TRAINER_RIVAL_TOTODILE_3                      326
-#define TRAINER_KENNETH                      327
-#define TRAINER_FIDEL                    328
-#define TRAINER_FRAN                    329
-#define TRAINER_FRITZ                    330
-#define TRAINER_GAKU                    331
-#define TRAINER_EDDIE                       332
-#define TRAINER_ALLEN                       333
-#define TRAINER_TIMMY                       334
-#define TRAINER_WALLACE                     335
-#define TRAINER_ANDREW                      336
-#define TRAINER_IVAN                        337
-#define TRAINER_CLAUDE                      338
-#define TRAINER_MASA                    339
-#define TRAINER_NED                         340
-#define TRAINER_DALE                        341
-#define TRAINER_NOLAN                       342
-#define TRAINER_CYBIL                       343
-#define TRAINER_WADE                        344
-#define TRAINER_CARTER                      345
-#define TRAINER_MATHEW                    346
-#define TRAINER_MEG_AND_PEG                    347
-#define TRAINER_MEGAN                    348
+#define TRAINER_JANINE                     305
+#define TRAINER_BLAINE                     306
+#define TRAINER_TIMOTHY_1                  307 // UNUSED
+#define TRAINER_TIMOTHY_2                  308 // UNUSED
+#define TRAINER_TIMOTHY_3                  309 // UNUSED
+#define TRAINER_TIMOTHY_4                  310 // UNUSED
+#define TRAINER_TIMOTHY_5                  311 // UNUSED
+#define TRAINER_VICKY                      312 // UNUSED
+#define TRAINER_SHELBY_1                   313 // UNUSED
+#define TRAINER_SHELBY_2                   314 // UNUSED
+#define TRAINER_SHELBY_3                   315 // UNUSED
+#define TRAINER_SHELBY_4                   316 // UNUSED
+#define TRAINER_SHELBY_5                   317 // UNUSED
+#define TRAINER_EUGENE                     318
+#define TRAINER_BILLY                      319
+#define TRAINER_JOSH                       320
+#define TRAINER_TOMMY                      321
+#define TRAINER_JOEY                       322
+#define TRAINER_BEN                        323
+#define TRAINER_QUINCY                     324 // UNUSED
+#define TRAINER_KATELYNN                   325 // UNUSED
+#define TRAINER_RIVAL_TOTODILE_3           326
+#define TRAINER_KENNETH                    327
+#define TRAINER_FIDEL                      328
+#define TRAINER_FRAN                       329
+#define TRAINER_FRITZ                      330
+#define TRAINER_GAKU                       331 // UNUSED
+#define TRAINER_EDDIE                      332
+#define TRAINER_ALLEN                      333
+#define TRAINER_TIMMY                      334 // UNUSED
+#define TRAINER_WALLACE                    335 // UNUSED
+#define TRAINER_ANDREW                     336
+#define TRAINER_IVAN                       337
+#define TRAINER_CLAUDE                     338 // UNUSED
+#define TRAINER_MASA                       339 // UNUSED
+#define TRAINER_NED                        340 // UNUSED
+#define TRAINER_DALE                       341 // UNUSED
+#define TRAINER_NOLAN                      342 // UNUSED
+#define TRAINER_CYBIL                      343
+#define TRAINER_WADE                       344
+#define TRAINER_CARTER                     345
+#define TRAINER_MATHEW                     346
+#define TRAINER_MEG_AND_PEG                347
+#define TRAINER_MEGAN                      348
 #define TRAINER_MICHAEL                    349
-#define TRAINER_RONALD                      350
-#define TRAINER_RIVAL_CYNDAQUIL_2                       351
-#define TRAINER_ANTHONY                     352
-#define TRAINER_BENJAMIN_1                  353
-#define TRAINER_BENJAMIN_2                  354
-#define TRAINER_BENJAMIN_3                  355
-#define TRAINER_BENJAMIN_4                  356
-#define TRAINER_BENJAMIN_5                  357
-#define TRAINER_ABE                   358
-#define TRAINER_JASMINE                     359
-#define TRAINER_AL                   360
-#define TRAINER_ALFRED                   361
-#define TRAINER_ALLAN                   362
-#define TRAINER_ANDRE                   363
-#define TRAINER_LEWIS                     364
-#define TRAINER_LI                     365
-#define TRAINER_LISA                     366
-#define TRAINER_LIZ                     367
-#define TRAINER_LLOYD                     368
-#define TRAINER_MARIA_1                     369
-#define TRAINER_MARIA_2                     370
-#define TRAINER_MARIA_3                     371
-#define TRAINER_MARIA_4                     372
-#define TRAINER_MARIA_5                     373
-#define TRAINER_GARRETT                      374
-#define TRAINER_JULIA                   375
-#define TRAINER_WILL_2                    376
-#define TRAINER_PABLO_1                     377
-#define TRAINER_GRUNT_14                       378
+#define TRAINER_RONALD                     350
+#define TRAINER_RIVAL_CYNDAQUIL_2          351
+#define TRAINER_ANTHONY                    352
+#define TRAINER_BENJAMIN_1                 353 // UNUSED
+#define TRAINER_BENJAMIN_2                 354 // UNUSED
+#define TRAINER_BENJAMIN_3                 355 // UNUSED
+#define TRAINER_BENJAMIN_4                 356 // UNUSED
+#define TRAINER_BENJAMIN_5                 357 // UNUSED
+#define TRAINER_ABE                        358
+#define TRAINER_JASMINE                    359 // UNUSED
+#define TRAINER_AL                         360
+#define TRAINER_ALFRED                     361
+#define TRAINER_ALLAN                      362
+#define TRAINER_ANDRE                      363
+#define TRAINER_LEWIS                      364 // UNUSED
+#define TRAINER_LI                         365
+#define TRAINER_LISA                       366 // UNUSED
+#define TRAINER_LIZ                        367
+#define TRAINER_LLOYD                      368
+#define TRAINER_MARIA_1                    369 // UNUSED
+#define TRAINER_MARIA_2                    370 // UNUSED
+#define TRAINER_MARIA_3                    371 // UNUSED
+#define TRAINER_MARIA_4                    372 // UNUSED
+#define TRAINER_MARIA_5                    373 // UNUSED
+#define TRAINER_GARRETT                    374
+#define TRAINER_JULIA                      375
+#define TRAINER_WILL_2                     376
+#define TRAINER_PABLO_1                    377 // UNUSED
+#define TRAINER_GRUNT_14                   378
 #define TRAINER_BRUNO_1                    379
 #define TRAINER_BRUNO_2                    380
 #define TRAINER_KAREN_1                    381
 #define TRAINER_KAREN_2                    382
-#define TRAINER_KOGA_1                      383
-#define TRAINER_KIM                       384
-#define TRAINER_TALIA                       385
-#define TRAINER_KATELYN_1                   386
-#define TRAINER_BOB                     387
-#define TRAINER_KATELYN_2                   388
-#define TRAINER_KATELYN_3                   389
-#define TRAINER_KATELYN_4                   390
-#define TRAINER_KATELYN_5                   391
-#define TRAINER_NICOLAS_1                   392
-#define TRAINER_NICOLAS_2                   393
-#define TRAINER_NICOLAS_3                   394
-#define TRAINER_NICOLAS_4                   395
-#define TRAINER_NICOLAS_5                   396
-#define TRAINER_AARON                       397
-#define TRAINER_PERRY                       398
-#define TRAINER_HUGH                        399
-#define TRAINER_PHIL                        400
-#define TRAINER_JARED                       401
+#define TRAINER_KOGA_1                     383
+#define TRAINER_KIM                        384
+#define TRAINER_TALIA                      385 // UNUSED
+#define TRAINER_KATELYN_1                  386 // UNUSED
+#define TRAINER_BOB                        387
+#define TRAINER_KATELYN_2                  388 // UNUSED
+#define TRAINER_KATELYN_3                  389 // UNUSED
+#define TRAINER_KATELYN_4                  390 // UNUSED
+#define TRAINER_KATELYN_5                  391 // UNUSED
+#define TRAINER_NICOLAS_1                  392 // UNUSED
+#define TRAINER_NICOLAS_2                  393 // UNUSED
+#define TRAINER_NICOLAS_3                  394 // UNUSED
+#define TRAINER_NICOLAS_4                  395 // UNUSED
+#define TRAINER_NICOLAS_5                  396 // UNUSED
+#define TRAINER_AARON                      397
+#define TRAINER_PERRY                      398
+#define TRAINER_HUGH                       399
+#define TRAINER_PHIL                       400
+#define TRAINER_JARED                      401
 #define TRAINER_CHUCK_2                    402
-#define TRAINER_PRESLEY                     403
-#define TRAINER_LOIS                     404
-#define TRAINER_COLIN                       405
-#define TRAINER_ROBERT_1                    406
-#define TRAINER_BENNY                       407
-#define TRAINER_GRUNT_15                     408
-#define TRAINER_ROBERT_2                    409
-#define TRAINER_ROBERT_3                    410
-#define TRAINER_ROBERT_4                    411
-#define TRAINER_ROBERT_5                    412
-#define TRAINER_ALEX                        413
-#define TRAINER_DANNY                        414
-#define TRAINER_YASU                        415
-#define TRAINER_TAKASHI                     416
+#define TRAINER_PRESLEY                    403 // UNUSED
+#define TRAINER_LOIS                       404
+#define TRAINER_COLIN                      405
+#define TRAINER_ROBERT_1                   406 // UNUSED
+#define TRAINER_BENNY                      407
+#define TRAINER_GRUNT_15                   408
+#define TRAINER_ROBERT_2                   409 // UNUSED
+#define TRAINER_ROBERT_3                   410 // UNUSED
+#define TRAINER_ROBERT_4                   411 // UNUSED
+#define TRAINER_ROBERT_5                   412 // UNUSED
+#define TRAINER_ALEX                       413
+#define TRAINER_DANNY                      414
+#define TRAINER_YASU                       415 // UNUSED
+#define TRAINER_TAKASHI                    416 // UNUSED
 #define TRAINER_KENJI                      417
-#define TRAINER_JANI                        418
-#define TRAINER_LAO_1                       419
-#define TRAINER_LUNG                        420
-#define TRAINER_LAO_2                       421
-#define TRAINER_LAO_3                       422
-#define TRAINER_LAO_4                       423
-#define TRAINER_LAO_5                       424
-#define TRAINER_JOCELYN                     425
-#define TRAINER_LAURA                       426
-#define TRAINER_JASMINE_2                   427
-#define TRAINER_GRUNT_28                        428
-#define TRAINER_PAULA                       429
-#define TRAINER_JAKE                     430
-#define TRAINER_JAMES                     431
-#define TRAINER_JASON                     432
-#define TRAINER_JAY                     433
-#define TRAINER_MADELINE_1                  434
-#define TRAINER_CLARISSA                    435
-#define TRAINER_ANGELICA                    436
-#define TRAINER_MADELINE_2                  437
-#define TRAINER_MADELINE_3                  438
-#define TRAINER_MADELINE_4                  439
-#define TRAINER_MADELINE_5                  440
-#define TRAINER_BEVERLY                     441
-#define TRAINER_CHUCK_1_2                       442
-#define TRAINER_KYLA                        443
-#define TRAINER_DENISE                      444
-#define TRAINER_BETH                        445
-#define TRAINER_TARA                        446
-#define TRAINER_MISSY                       447
-#define TRAINER_ALICE                       448
-#define TRAINER_GRUNT_30                     449
-#define TRAINER_GRACE                       450
-#define TRAINER_TANYA                       451
-#define TRAINER_SHARON                      452
-#define TRAINER_NIKKI                       453
-#define TRAINER_BRENDA                      454
-#define TRAINER_KATIE                       455
-#define TRAINER_SUSIE                       456
-#define TRAINER_KARA                        457
-#define TRAINER_DANA                        458
-#define TRAINER_SIENNA                      459
-#define TRAINER_DEBRA                       460
-#define TRAINER_LINDA                       461
-#define TRAINER_KAYLEE                      462
-#define TRAINER_LAUREL                      463
-#define TRAINER_GRUNT                      464
-#define TRAINER_GRUNT_31                     465
-#define TRAINER_GRUNT_32                     466
-#define TRAINER_PETREL_1                     467
+#define TRAINER_JANI                       418 // UNUSED
+#define TRAINER_LAO_1                      419 // UNUSED
+#define TRAINER_LUNG                       420
+#define TRAINER_LAO_2                      421 // UNUSED
+#define TRAINER_LAO_3                      422 // UNUSED
+#define TRAINER_LAO_4                      423 // UNUSED
+#define TRAINER_LAO_5                      424 // UNUSED
+#define TRAINER_JOCELYN                    425 // UNUSED
+#define TRAINER_LAURA                      426
+#define TRAINER_JASMINE_2                  427
+#define TRAINER_GRUNT_28                   428
+#define TRAINER_PAULA                      429
+#define TRAINER_JAKE                       430
+#define TRAINER_JAMES                      431 // UNUSED
+#define TRAINER_JASON                      432
+#define TRAINER_JAY                        433 // UNUSED
+#define TRAINER_MADELINE_1                 434 // UNUSED
+#define TRAINER_CLARISSA                   435
+#define TRAINER_ANGELICA                   436 // UNUSED
+#define TRAINER_MADELINE_2                 437 // UNUSED
+#define TRAINER_MADELINE_3                 438 // UNUSED
+#define TRAINER_MADELINE_4                 439 // UNUSED
+#define TRAINER_MADELINE_5                 440 // UNUSED
+#define TRAINER_BEVERLY                    441
+#define TRAINER_CHUCK_1_2                  442
+#define TRAINER_KYLA                       443 // UNUSED
+#define TRAINER_DENISE                     444
+#define TRAINER_BETH                       445
+#define TRAINER_TARA                       446 // UNUSED
+#define TRAINER_MISSY                      447 // UNUSED
+#define TRAINER_ALICE                      448
+#define TRAINER_GRUNT_30                   449 // UNUSED
+#define TRAINER_GRACE                      450
+#define TRAINER_TANYA                      451
+#define TRAINER_SHARON                     452
+#define TRAINER_NIKKI                      453
+#define TRAINER_BRENDA                     454 // UNUSED
+#define TRAINER_KATIE                      455 // UNUSED
+#define TRAINER_SUSIE                      456
+#define TRAINER_KARA                       457
+#define TRAINER_DANA                       458
+#define TRAINER_SIENNA                     459 // UNUSED
+#define TRAINER_DEBRA                      460
+#define TRAINER_LINDA                      461
+#define TRAINER_KAYLEE                     462
+#define TRAINER_LAUREL                     463 // UNUSED
+#define TRAINER_GRUNT                      464 // UNUSED
+#define TRAINER_GRUNT_31                   465
+#define TRAINER_GRUNT_32                   466 // UNUSED
+#define TRAINER_PETREL_1                   467
 #define TRAINER_ARCHER                     468
-#define TRAINER_HEIDI                       469
-#define TRAINER_DARIN                       470
-#define TRAINER_CAROL                       471
-#define TRAINER_NANCY                       472
-#define TRAINER_MARTHA                      473
-#define TRAINER_KAZU                     474
-#define TRAINER_GRUNT_8                      475
-#define TRAINER_IRENE                       476
-#define TRAINER_KEITH                     477
-#define TRAINER_KELLY                     478
-#define TRAINER_KEN                     479
-#define TRAINER_KEANDRA                     480
-#define TRAINER_AMY_AND_MAY               481
+#define TRAINER_HEIDI                      469
+#define TRAINER_DARIN                      470
+#define TRAINER_CAROL                      471
+#define TRAINER_NANCY                      472 // UNUSED
+#define TRAINER_MARTHA                     473
+#define TRAINER_KAZU                       474 // UNUSED
+#define TRAINER_GRUNT_8                    475
+#define TRAINER_IRENE                      476
+#define TRAINER_KEITH                      477
+#define TRAINER_KELLY                      478
+#define TRAINER_KEN                        479
+#define TRAINER_KEANDRA                    480 // UNUSED
+#define TRAINER_AMY_AND_MAY                481
 #define TRAINER_ANN_AND_ANNE               482
-#define TRAINER_RUTH              483
-#define TRAINER_MIU_AND_YUKI                484
-#define TRAINER_AMY_AND_LIV_3               485
-#define TRAINER_RYAN              486
-#define TRAINER_AMY_AND_LIV_4               487
-#define TRAINER_AMY_AND_LIV_5               488
-#define TRAINER_AMY_AND_LIV_6               489
-#define TRAINER_HUEY                        490
-#define TRAINER_EDMOND                      491
-#define TRAINER_MIKE                    492
-#define TRAINER_DWAYNE                      493
-#define TRAINER_PHILLIP                     494
-#define TRAINER_LEONARD                     495
-#define TRAINER_DUNCAN                      496
-#define TRAINER_MIKEY                    497
-#define TRAINER_MIKI                    498
-#define TRAINER_MILLER                    499
-#define TRAINER_MITCH                    500
-#define TRAINER_ELI                         501
-#define TRAINER_CARRIE                      502
-#define TRAINER_RIVAL_TOTODILE_4                      503
-#define TRAINER_JONAS                       504
-#define TRAINER_KAYLEY                      505
-#define TRAINER_CLYDE                       506
-#define TRAINER_KELVIN                      507
-#define TRAINER_MARLEY                      508
-#define TRAINER_REYNA                       509
-#define TRAINER_CHUCK_1                      510
-#define TRAINER_GRUNT_27                       511
-#define TRAINER_LOLA                     512
-#define TRAINER_JASMINE_1                      513
-#define TRAINER_TABITHA_MOSSDEEP            514
-#define TRAINER_LORI                     515
-#define TRAINER_MARGRET                     516
+#define TRAINER_RUTH                       483
+#define TRAINER_MIU_AND_YUKI               484 // UNUSED
+#define TRAINER_AMY_AND_LIV_3              485 // UNUSED
+#define TRAINER_RYAN                       486
+#define TRAINER_AMY_AND_LIV_4              487 // UNUSED
+#define TRAINER_AMY_AND_LIV_5              488 // UNUSED
+#define TRAINER_AMY_AND_LIV_6              489 // UNUSED
+#define TRAINER_HUEY                       490
+#define TRAINER_EDMOND                     491
+#define TRAINER_MIKE                       492
+#define TRAINER_DWAYNE                     493
+#define TRAINER_PHILLIP                    494
+#define TRAINER_LEONARD                    495
+#define TRAINER_DUNCAN                     496
+#define TRAINER_MIKEY                      497
+#define TRAINER_MIKI                       498
+#define TRAINER_MILLER                     499
+#define TRAINER_MITCH                      500
+#define TRAINER_ELI                        501 // UNUSED
+#define TRAINER_CARRIE                     502
+#define TRAINER_RIVAL_TOTODILE_4           503
+#define TRAINER_JONAS                      504 // UNUSED
+#define TRAINER_KAYLEY                     505 // UNUSED
+#define TRAINER_CLYDE                      506
+#define TRAINER_KELVIN                     507 // UNUSED
+#define TRAINER_MARLEY                     508 // UNUSED
+#define TRAINER_REYNA                      509 // UNUSED
+#define TRAINER_CHUCK_1                    510
+#define TRAINER_GRUNT_27                   511
+#define TRAINER_LOLA                       512
+#define TRAINER_JASMINE_1                  513
+#define TRAINER_TABITHA_MOSSDEEP           514 // UNUSED
+#define TRAINER_LORI                       515
+#define TRAINER_MARGRET                    516 // UNUSED
 #define TRAINER_MARKUS                     517
 #define TRAINER_MARTIN                     518
-#define TRAINER_WALLY_VR_1                  519
-#define TRAINER_THOM_AND_KAE    520
-#define TRAINER_DUFF_AND_EDA    521
-#define TRAINER_BRENDAN_ROUTE_119_MUDKIP    522
-#define TRAINER_BRENDAN_ROUTE_103_TREECKO   523
-#define TRAINER_BRENDAN_ROUTE_110_TREECKO   524
-#define TRAINER_BRENDAN_ROUTE_119_TREECKO   525
-#define TRAINER_BRENDAN_ROUTE_103_TORCHIC   526
-#define TRAINER_BRENDAN_ROUTE_110_TORCHIC   527
-#define TRAINER_BRENDAN_ROUTE_119_TORCHIC   528
-#define TRAINER_MAY_ROUTE_103_MUDKIP        529
-#define TRAINER_MAY_ROUTE_110_MUDKIP        530
-#define TRAINER_MAY_ROUTE_119_MUDKIP        531
-#define TRAINER_MAY_ROUTE_103_TREECKO       532
-#define TRAINER_MAY_ROUTE_110_TREECKO       533
-#define TRAINER_MAY_ROUTE_119_TREECKO       534
-#define TRAINER_MAY_ROUTE_103_TORCHIC       535
-#define TRAINER_MAY_ROUTE_110_TORCHIC       536
-#define TRAINER_MAY_ROUTE_119_TORCHIC       537
-#define TRAINER_CHUCK_1_3                     538
-#define TRAINER_JOE                       539
-#define TRAINER_MITCHELL                    540
-#define TRAINER_CLAIR_1                     541
-#define TRAINER_CLAIR_2                     542
-#define TRAINER_BROCK                     543
-#define TRAINER_MISTY                     544
-#define TRAINER_LYDIA_1                     545
-#define TRAINER_PRYCE_1                       546
-#define TRAINER_RUSS                    547
-#define TRAINER_LYDIA_2                     548
-#define TRAINER_LYDIA_3                     549
-#define TRAINER_LYDIA_4                     550
-#define TRAINER_LYDIA_5                     551
-#define TRAINER_RIVAL_CHIKORITA_4                   552
-#define TRAINER_LORENZO                     553
-#define TRAINER_SEBASTIAN                   554
-#define TRAINER_RIVAL_CHIKORITA_5                   555
-#define TRAINER_RIVAL_CHIKORITA_6                   556
-#define TRAINER_RIVAL_CHIKORITA_7                   557
-#define TRAINER_RIVAL_CYNDAQUIL_1                   558
-#define TRAINER_GRUNT_3                 559
-#define TRAINER_EUSINE                       560
-#define TRAINER_SOPHIA                      561
-#define TRAINER_GRUNT_4                 562
-#define TRAINER_GRUNT_5                 563
-#define TRAINER_GRUNT_6                 564
-#define TRAINER_GRUNT_7                 565
-#define TRAINER_JULIO                       566
-#define TRAINER_VANCE     567
-#define TRAINER_STEVEN2                     568
-#define TRAINER_TOBY             569
-#define TRAINER_TERRELL           570
-#define TRAINER_MARC                        571
-#define TRAINER_BRENDEN                     572
-#define TRAINER_LILITH                      573
-#define TRAINER_HARVEY                    574
-#define TRAINER_SYLVIA                      575
-#define TRAINER_LEONARDO                    576
-#define TRAINER_CHOW                      577
-#define TRAINER_PRYCE_1_2                    578
-#define TRAINER_THEO          579
-#define TRAINER_GRUNT_24                    580
-#define TRAINER_TERRY                       581
-#define TRAINER_NATE                        582
-#define TRAINER_KATHLEEN                    583
-#define TRAINER_CLIFFORD                    584
-#define TRAINER_NICHOLAS                    585
-#define TRAINER_WALT        586
-#define TRAINER_WALTER        587
-#define TRAINER_WILTON        588
-#define TRAINER_YOSHI        589
-#define TRAINER_ZACH        590
-#define TRAINER_MACEY                       591
-#define TRAINER_BRENDAN_RUSTBORO_TREECKO    592
-#define TRAINER_BRENDAN_RUSTBORO_MUDKIP     593
-#define TRAINER_PAXTON                      594
-#define TRAINER_BLUE                    595
-#define TRAINER_BUGSY_1        596
-#define TRAINER_TABITHA_MT_CHIMNEY          597
-#define TRAINER_JONATHAN                    598
-#define TRAINER_BRENDAN_RUSTBORO_TORCHIC    599
-#define TRAINER_MAY_RUSTBORO_MUDKIP         600
-#define TRAINER_MAXIE_MAGMA_HIDEOUT         601
-#define TRAINER_MAXIE_MT_CHIMNEY            602
-#define TRAINER_TIANA                       603
-#define TRAINER_WHITNEY_1                     604
-#define TRAINER_RIVAL_TOTODILE_1                      605
-#define TRAINER_VIVI                        606
-#define TRAINER_WHITNEY_2                     607
-#define TRAINER_MORTY_1                     608
-#define TRAINER_MORTY_2                     609
-#define TRAINER_JAMIE                    610
-#define TRAINER_SALLY                       611
-#define TRAINER_ROBIN                       612
+#define TRAINER_WALLY_VR_1                 519 // UNUSED
+#define TRAINER_THOM_AND_KAE               520
+#define TRAINER_DUFF_AND_EDA               521
+#define TRAINER_BRENDAN_ROUTE_119_MUDKIP   522 // UNUSED
+#define TRAINER_BRENDAN_ROUTE_103_TREECKO  523 // UNUSED
+#define TRAINER_BRENDAN_ROUTE_110_TREECKO  524 // UNUSED
+#define TRAINER_BRENDAN_ROUTE_119_TREECKO  525 // UNUSED
+#define TRAINER_BRENDAN_ROUTE_103_TORCHIC  526 // UNUSED
+#define TRAINER_BRENDAN_ROUTE_110_TORCHIC  527 // UNUSED
+#define TRAINER_BRENDAN_ROUTE_119_TORCHIC  528 // UNUSED
+#define TRAINER_MAY_ROUTE_103_MUDKIP       529 // UNUSED
+#define TRAINER_MAY_ROUTE_110_MUDKIP       530 // UNUSED
+#define TRAINER_MAY_ROUTE_119_MUDKIP       531 // UNUSED
+#define TRAINER_MAY_ROUTE_103_TREECKO      532 // UNUSED
+#define TRAINER_MAY_ROUTE_110_TREECKO      533 // UNUSED
+#define TRAINER_MAY_ROUTE_119_TREECKO      534 // UNUSED
+#define TRAINER_MAY_ROUTE_103_TORCHIC      535 // UNUSED
+#define TRAINER_MAY_ROUTE_110_TORCHIC      536 // UNUSED
+#define TRAINER_MAY_ROUTE_119_TORCHIC      537 // UNUSED
+#define TRAINER_CHUCK_1_3                  538
+#define TRAINER_JOE                        539
+#define TRAINER_MITCHELL                   540 // UNUSED
+#define TRAINER_CLAIR_1                    541
+#define TRAINER_CLAIR_2                    542
+#define TRAINER_BROCK                      543
+#define TRAINER_MISTY                      544
+#define TRAINER_LYDIA_1                    545 // UNUSED
+#define TRAINER_PRYCE_1                    546
+#define TRAINER_RUSS                       547 // UNUSED
+#define TRAINER_LYDIA_2                    548 // UNUSED
+#define TRAINER_LYDIA_3                    549 // UNUSED
+#define TRAINER_LYDIA_4                    550 // UNUSED
+#define TRAINER_LYDIA_5                    551 // UNUSED
+#define TRAINER_RIVAL_CHIKORITA_4          552
+#define TRAINER_LORENZO                    553 // UNUSED
+#define TRAINER_SEBASTIAN                  554 // UNUSED
+#define TRAINER_RIVAL_CHIKORITA_5          555
+#define TRAINER_RIVAL_CHIKORITA_6          556
+#define TRAINER_RIVAL_CHIKORITA_7          557
+#define TRAINER_RIVAL_CYNDAQUIL_1          558
+#define TRAINER_GRUNT_3                    559
+#define TRAINER_EUSINE                     560
+#define TRAINER_SOPHIA                     561 // UNUSED
+#define TRAINER_GRUNT_4                    562
+#define TRAINER_GRUNT_5                    563
+#define TRAINER_GRUNT_6                    564
+#define TRAINER_GRUNT_7                    565
+#define TRAINER_JULIO                      566 // UNUSED
+#define TRAINER_VANCE                      567
+#define TRAINER_STEVEN2                    568 // UNUSED
+#define TRAINER_TOBY                       569
+#define TRAINER_TERRELL                    570
+#define TRAINER_MARC                       571
+#define TRAINER_BRENDEN                    572 // UNUSED
+#define TRAINER_LILITH                     573 // UNUSED
+#define TRAINER_HARVEY                     574 // UNUSED
+#define TRAINER_SYLVIA                     575 // UNUSED
+#define TRAINER_LEONARDO                   576 // UNUSED
+#define TRAINER_CHOW                       577
+#define TRAINER_PRYCE_1_2                  578
+#define TRAINER_THEO                       579
+#define TRAINER_GRUNT_24                   580 // UNUSED
+#define TRAINER_TERRY                      581 // UNUSED
+#define TRAINER_NATE                       582
+#define TRAINER_KATHLEEN                   583 // UNUSED
+#define TRAINER_CLIFFORD                   584 // UNUSED
+#define TRAINER_NICHOLAS                   585 // UNUSED
+#define TRAINER_WALT                       586
+#define TRAINER_WALTER                     587 // UNUSED
+#define TRAINER_WILTON                     588
+#define TRAINER_YOSHI                      589
+#define TRAINER_ZACH                       590
+#define TRAINER_MACEY                      591 // UNUSED
+#define TRAINER_BRENDAN_RUSTBORO_TREECKO   592 // UNUSED
+#define TRAINER_BRENDAN_RUSTBORO_MUDKIP    593 // UNUSED
+#define TRAINER_PAXTON                     594 // UNUSED
+#define TRAINER_BLUE                       595
+#define TRAINER_BUGSY_1                    596
+#define TRAINER_TABITHA_MT_CHIMNEY         597 // UNUSED
+#define TRAINER_JONATHAN                   598 // UNUSED
+#define TRAINER_BRENDAN_RUSTBORO_TORCHIC   599 // UNUSED
+#define TRAINER_MAY_RUSTBORO_MUDKIP        600 // UNUSED
+#define TRAINER_MAXIE_MAGMA_HIDEOUT        601 // UNUSED
+#define TRAINER_MAXIE_MT_CHIMNEY           602 // UNUSED
+#define TRAINER_TIANA                      603
+#define TRAINER_WHITNEY_1                  604
+#define TRAINER_RIVAL_TOTODILE_1           605
+#define TRAINER_VIVI                       606 // UNUSED
+#define TRAINER_WHITNEY_2                  607
+#define TRAINER_MORTY_1                    608
+#define TRAINER_MORTY_2                    609
+#define TRAINER_JAMIE                      610
+#define TRAINER_SALLY                      611 // UNUSED
+#define TRAINER_ROBIN                      612 // UNUSED
 #define TRAINER_BRIAN                      613
 #define TRAINER_HARRY                      614
-#define TRAINER_RICK                        615
-#define TRAINER_LYLE                        616
-#define TRAINER_JOSE                        617
-#define TRAINER_DOUG                        618
-#define TRAINER_GREG                        619
-#define TRAINER_KENT                        620
-#define TRAINER_RIVAL_CYNDAQUIL_4                     621
-#define TRAINER_RIVAL_CYNDAQUIL_5                     622
-#define TRAINER_RIVAL_CYNDAQUIL_6                     623
-#define TRAINER_RIVAL_CYNDAQUIL_7                     624
-#define TRAINER_RIVAL_TOTODILE_2                     625
-#define TRAINER_ELLIOT                       626
-#define TRAINER_TRENT_1                     627
-#define TRAINER_LENNY                       628
-#define TRAINER_LUCAS_1                     629
-#define TRAINER_ALAN                        630
-#define TRAINER_CLARK                       631
-#define TRAINER_ERIC                        632
-#define TRAINER_LUCAS_2                     633
-#define TRAINER_MIKE_1                      634
-#define TRAINER_MIKE_2                      635
-#define TRAINER_TRENT_2                     636
-#define TRAINER_TRENT_3                     637
-#define TRAINER_TRENT_4                     638
-#define TRAINER_TRENT_5                     639
-#define TRAINER_DEZ_AND_LUKE                640
-#define TRAINER_LEA_AND_JED                 641
-#define TRAINER_KIRA_AND_DAN_1              642
-#define TRAINER_KIRA_AND_DAN_2              643
-#define TRAINER_KIRA_AND_DAN_3              644
-#define TRAINER_KIRA_AND_DAN_4              645
-#define TRAINER_KIRA_AND_DAN_5              646
-#define TRAINER_JOHANNA                     647
-#define TRAINER_RUSSELL                      648
-#define TRAINER_VIVIAN                      649
-#define TRAINER_KENDRA                    650
-#define TRAINER_JASMINE_1_2                       651
-#define TRAINER_KEIGO                       652
-#define TRAINER_RILEY                       653
-#define TRAINER_RAY                       654
-#define TRAINER_CHARLES                      655
-#define TRAINER_WALLY_MAUVILLE              656
-#define TRAINER_WALLY_VR_2                  657
-#define TRAINER_WALLY_VR_3                  658
-#define TRAINER_WALLY_VR_4                  659
-#define TRAINER_WALLY_VR_5                  660
-#define TRAINER_BRENDAN_LILYCOVE_MUDKIP     661
-#define TRAINER_BRENDAN_LILYCOVE_TREECKO    662
-#define TRAINER_BRENDAN_LILYCOVE_TORCHIC    663
-#define TRAINER_MAY_LILYCOVE_MUDKIP         664
-#define TRAINER_MAY_LILYCOVE_TREECKO        665
-#define TRAINER_MAY_LILYCOVE_TORCHIC        666
-#define TRAINER_JONAH                       667
-#define TRAINER_HENRY                       668
-#define TRAINER_ROGER                       669
-#define TRAINER_BAILEY                       670
-#define TRAINER_RUBEN                       671
-#define TRAINER_KOJI_1                      672
-#define TRAINER_WAYNE                       673
-#define TRAINER_ANDY                       674
-#define TRAINER_REED                        675
-#define TRAINER_TISHA                       676
-#define TRAINER_TORI_AND_TIA                677
-#define TRAINER_KIM_AND_IRIS                678
-#define TRAINER_TYRA_AND_IVY                679
-#define TRAINER_MEL_AND_PAUL                680
-#define TRAINER_JOHN_AND_JAY_1              681
-#define TRAINER_JOHN_AND_JAY_2              682
-#define TRAINER_JOHN_AND_JAY_3              683
-#define TRAINER_JOHN_AND_JAY_4              684
-#define TRAINER_JOHN_AND_JAY_5              685
-#define TRAINER_RELI_AND_IAN                686
-#define TRAINER_LILA_AND_ROY_1              687
-#define TRAINER_LILA_AND_ROY_2              688
-#define TRAINER_LILA_AND_ROY_3              689
-#define TRAINER_LILA_AND_ROY_4              690
-#define TRAINER_LILA_AND_ROY_5              691
-#define TRAINER_LISA_AND_RAY                692
-#define TRAINER_GRUNT_17                       693
-#define TRAINER_JOEL                      694
-#define TRAINER_SARAH                       695
+#define TRAINER_RICK                       615 // UNUSED
+#define TRAINER_LYLE                       616
+#define TRAINER_JOSE                       617
+#define TRAINER_DOUG                       618
+#define TRAINER_GREG                       619
+#define TRAINER_KENT                       620
+#define TRAINER_RIVAL_CYNDAQUIL_4          621
+#define TRAINER_RIVAL_CYNDAQUIL_5          622
+#define TRAINER_RIVAL_CYNDAQUIL_6          623
+#define TRAINER_RIVAL_CYNDAQUIL_7          624
+#define TRAINER_RIVAL_TOTODILE_2           625
+#define TRAINER_ELLIOT                     626
+#define TRAINER_TRENT_1                    627 // UNUSED
+#define TRAINER_LENNY                      628 // UNUSED
+#define TRAINER_LUCAS_1                    629 // UNUSED
+#define TRAINER_ALAN                       630
+#define TRAINER_CLARK                      631 // UNUSED
+#define TRAINER_ERIC                       632
+#define TRAINER_LUCAS_2                    633 // UNUSED
+#define TRAINER_MIKE_1                     634 // UNUSED
+#define TRAINER_MIKE_2                     635 // UNUSED
+#define TRAINER_TRENT_2                    636 // UNUSED
+#define TRAINER_TRENT_3                    637 // UNUSED
+#define TRAINER_TRENT_4                    638 // UNUSED
+#define TRAINER_TRENT_5                    639 // UNUSED
+#define TRAINER_DEZ_AND_LUKE               640 // UNUSED
+#define TRAINER_LEA_AND_JED                641 // UNUSED
+#define TRAINER_KIRA_AND_DAN_1             642 // UNUSED
+#define TRAINER_KIRA_AND_DAN_2             643 // UNUSED
+#define TRAINER_KIRA_AND_DAN_3             644 // UNUSED
+#define TRAINER_KIRA_AND_DAN_4             645 // UNUSED
+#define TRAINER_KIRA_AND_DAN_5             646 // UNUSED
+#define TRAINER_JOHANNA                    647 // UNUSED
+#define TRAINER_RUSSELL                    648
+#define TRAINER_VIVIAN                     649 // UNUSED
+#define TRAINER_KENDRA                     650 // UNUSED
+#define TRAINER_JASMINE_1_2                651
+#define TRAINER_KEIGO                      652 // UNUSED
+#define TRAINER_RILEY                      653
+#define TRAINER_RAY                        654
+#define TRAINER_CHARLES                    655
+#define TRAINER_WALLY_MAUVILLE             656 // UNUSED
+#define TRAINER_WALLY_VR_2                 657 // UNUSED
+#define TRAINER_WALLY_VR_3                 658 // UNUSED
+#define TRAINER_WALLY_VR_4                 659 // UNUSED
+#define TRAINER_WALLY_VR_5                 660 // UNUSED
+#define TRAINER_BRENDAN_LILYCOVE_MUDKIP    661 // UNUSED
+#define TRAINER_BRENDAN_LILYCOVE_TREECKO   662 // UNUSED
+#define TRAINER_BRENDAN_LILYCOVE_TORCHIC   663 // UNUSED
+#define TRAINER_MAY_LILYCOVE_MUDKIP        664 // UNUSED
+#define TRAINER_MAY_LILYCOVE_TREECKO       665 // UNUSED
+#define TRAINER_MAY_LILYCOVE_TORCHIC       666 // UNUSED
+#define TRAINER_JONAH                      667
+#define TRAINER_HENRY                      668
+#define TRAINER_ROGER                      669 // UNUSED
+#define TRAINER_BAILEY                     670
+#define TRAINER_RUBEN                      671 // UNUSED
+#define TRAINER_KOJI_1                     672 // UNUSED
+#define TRAINER_WAYNE                      673
+#define TRAINER_ANDY                       674 // UNUSED
+#define TRAINER_REED                       675 // UNUSED
+#define TRAINER_TISHA                      676 // UNUSED
+#define TRAINER_TORI_AND_TIA               677 // UNUSED
+#define TRAINER_KIM_AND_IRIS               678 // UNUSED
+#define TRAINER_TYRA_AND_IVY               679 // UNUSED
+#define TRAINER_MEL_AND_PAUL               680 // UNUSED
+#define TRAINER_JOHN_AND_JAY_1             681 // UNUSED
+#define TRAINER_JOHN_AND_JAY_2             682 // UNUSED
+#define TRAINER_JOHN_AND_JAY_3             683 // UNUSED
+#define TRAINER_JOHN_AND_JAY_4             684 // UNUSED
+#define TRAINER_JOHN_AND_JAY_5             685 // UNUSED
+#define TRAINER_RELI_AND_IAN               686 // UNUSED
+#define TRAINER_LILA_AND_ROY_1             687 // UNUSED
+#define TRAINER_LILA_AND_ROY_2             688 // UNUSED
+#define TRAINER_LILA_AND_ROY_3             689 // UNUSED
+#define TRAINER_LILA_AND_ROY_4             690 // UNUSED
+#define TRAINER_LILA_AND_ROY_5             691 // UNUSED
+#define TRAINER_LISA_AND_RAY               692 // UNUSED
+#define TRAINER_GRUNT_17                   693
+#define TRAINER_JOEL                       694
+#define TRAINER_SARAH                      695 // UNUSED
 #define TRAINER_JIMMY                      696
-#define TRAINER_BUGSY_2                      697
-#define TRAINER_GRUNT_11                    698
-#define TRAINER_KALEB                       699
-#define TRAINER_JOSEPH                      700
-#define TRAINER_BRAD                      701
-#define TRAINER_MARCOS                      702
-#define TRAINER_RHETT                       703
-#define TRAINER_TYRON                       704
-#define TRAINER_GRUNT_10                      705
-#define TRAINER_BIANCA                      706
-#define TRAINER_PRYCE_1_3                      707
-#define TRAINER_SOPHIE                      708
-#define TRAINER_GRUNT_25                        709
-#define TRAINER_LAWRENCE                    710
-#define TRAINER_WYATT                       711
-#define TRAINER_CARA                    712
-#define TRAINER_KAI                         713
+#define TRAINER_BUGSY_2                    697
+#define TRAINER_GRUNT_11                   698
+#define TRAINER_KALEB                      699 // UNUSED
+#define TRAINER_JOSEPH                     700 // UNUSED
+#define TRAINER_BRAD                       701
+#define TRAINER_MARCOS                     702 // UNUSED
+#define TRAINER_RHETT                      703 // UNUSED
+#define TRAINER_TYRON                      704 // UNUSED
+#define TRAINER_GRUNT_10                   705
+#define TRAINER_BIANCA                     706 // UNUSED
+#define TRAINER_PRYCE_1_3                  707
+#define TRAINER_SOPHIE                     708 // UNUSED
+#define TRAINER_GRUNT_25                   709 // UNUSED
+#define TRAINER_LAWRENCE                   710 // UNUSED
+#define TRAINER_WYATT                      711 // UNUSED
+#define TRAINER_CARA                       712
+#define TRAINER_KAI                        713 // UNUSED
 #define TRAINER_GRUNT_13                   714
 #define TRAINER_JOHNNY                     715
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_1       716
-#define TRAINER_RICHARDO       717
-#define TRAINER_NARD       718
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_4       719
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_5       720
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_6       721
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_7       722
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_8       723
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_9       724
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_10      725
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_11      726
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_12      727
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_13      728
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_14      729
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_15      730
-#define TRAINER_GRUNT_MAGMA_HIDEOUT_16      731
-#define TRAINER_TABITHA_MAGMA_HIDEOUT       732
-#define TRAINER_JIM                       733
-#define TRAINER_MAXIE_MOSSDEEP              734
-#define TRAINER_PETE                        735
-#define TRAINER_WILL_1                    736
-#define TRAINER_BRIANA                    737
-#define TRAINER_JOSUE                       738
-#define TRAINER_GREGORY                      739
-#define TRAINER_GRUNT_29                      740
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_1      716 // UNUSED
+#define TRAINER_RICHARDO                   717
+#define TRAINER_NARD                       718
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_4      719 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_5      720 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_6      721 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_7      722 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_8      723 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_9      724 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_10     725 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_11     726 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_12     727 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_13     728 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_14     729 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_15     730 // UNUSED
+#define TRAINER_GRUNT_MAGMA_HIDEOUT_16     731 // UNUSED
+#define TRAINER_TABITHA_MAGMA_HIDEOUT      732 // UNUSED
+#define TRAINER_JIM                        733
+#define TRAINER_MAXIE_MOSSDEEP             734 // UNUSED
+#define TRAINER_PETE                       735 // UNUSED
+#define TRAINER_WILL_1                     736
+#define TRAINER_BRIANA                     737
+#define TRAINER_JOSUE                      738 // UNUSED
+#define TRAINER_GREGORY                    739
+#define TRAINER_GRUNT_29                   740
 #define TRAINER_GRUNT_2                    741
-#define TRAINER_MARVIN                      742
-#define TRAINER_GRUNT_9                       743
-#define TRAINER_BRYAN                       744
-#define TRAINER_BRANDEN                     745
+#define TRAINER_MARVIN                     742
+#define TRAINER_GRUNT_9                    743
+#define TRAINER_BRYAN                      744
+#define TRAINER_BRANDEN                    745 // UNUSED
 #define TRAINER_ETHAN                      746
-#define TRAINER_SHAYLA                      747
-#define TRAINER_KYRA                        748
-#define TRAINER_RIVAL_CYNDAQUIL_3                      749
-#define TRAINER_BILL                        750
-#define TRAINER_HELENE                     751
-#define TRAINER_MARLENE                     752
+#define TRAINER_SHAYLA                     747 // UNUSED
+#define TRAINER_KYRA                       748 // UNUSED
+#define TRAINER_RIVAL_CYNDAQUIL_3          749
+#define TRAINER_BILL                       750
+#define TRAINER_HELENE                     751 // UNUSED
+#define TRAINER_MARLENE                    752 // UNUSED
 #define TRAINER_KATE                       753
-#define TRAINER_JOHNSON                     754
-#define TRAINER_MELINA                      755
-#define TRAINER_BRANDI                      756
-#define TRAINER_ARNIE                       757
-#define TRAINER_MAKAYLA                     758
-#define TRAINER_NOB                      759
-#define TRAINER_JOHN                      760
-#define TRAINER_RACHEL                      761
-#define TRAINER_LEONEL                      762
-#define TRAINER_ETO                      763
-#define TRAINER_ETHEL                        764
-#define TRAINER_MYLES                       765
-#define TRAINER_PAT                         766
-#define TRAINER_HILLARY                   767
-#define TRAINER_MAY_RUSTBORO_TREECKO        768
-#define TRAINER_MAY_RUSTBORO_TORCHIC        769
-#define TRAINER_ROXANNE_2                   770
-#define TRAINER_ROXANNE_3                   771
-#define TRAINER_ROXANNE_4                   772
-#define TRAINER_ROXANNE_5                   773
-#define TRAINER_DIRK                    774
-#define TRAINER_DON                    775
-#define TRAINER_DORIS                    776
-#define TRAINER_EDNA                    777
-#define TRAINER_ETO_2                   778
-#define TRAINER_ETO_3                   779
-#define TRAINER_WATTSON_4                   780
-#define TRAINER_WATTSON_5                   781
-#define TRAINER_QUENTIN                  782
-#define TRAINER_QUINN                  783
-#define TRAINER_RACHAEL                  784
-#define TRAINER_RALPH                  785
-#define TRAINER_NORMAN_2                    786
-#define TRAINER_NORMAN_3                    787
-#define TRAINER_NORMAN_4                    788
-#define TRAINER_NORMAN_5                    789
-#define TRAINER_WINONA_2                    790
-#define TRAINER_WINONA_3                    791
-#define TRAINER_WINONA_4                    792
-#define TRAINER_WINONA_5                    793
-#define TRAINER_TATE_AND_LIZA_2             794
-#define TRAINER_TATE_AND_LIZA_3             795
-#define TRAINER_TATE_AND_LIZA_4             796
-#define TRAINER_TATE_AND_LIZA_5             797
-#define TRAINER_JUAN_2                      798
-#define TRAINER_JUAN_3                      799
-#define TRAINER_JUAN_4                      800
-#define TRAINER_JUAN_5                      801
-#define TRAINER_CARLENE                      802
-#define TRAINER_JIN                      803
-#define TRAINER_STEVEN                      804
-#define TRAINER_BRET                      805
-#define TRAINER_TUCKER                      806
-#define TRAINER_SPENSER                     807
-#define TRAINER_SAM                       808
-#define TRAINER_NOLAND                      809
-#define TRAINER_LUCY                        810
-#define TRAINER_BRANDON                     811
-#define TRAINER_BROOKE                    812
-#define TRAINER_BURT                    813
-#define TRAINER_CALVIN                    814
+#define TRAINER_JOHNSON                    754 // UNUSED
+#define TRAINER_MELINA                     755 // UNUSED
+#define TRAINER_BRANDI                     756 // UNUSED
+#define TRAINER_ARNIE                      757
+#define TRAINER_MAKAYLA                    758 // UNUSED
+#define TRAINER_NOB                        759
+#define TRAINER_JOHN                       760 // UNUSED
+#define TRAINER_RACHEL                     761 // UNUSED
+#define TRAINER_LEONEL                     762 // UNUSED
+#define TRAINER_ETO                        763
+#define TRAINER_ETHEL                      764 // UNUSED
+#define TRAINER_MYLES                      765 // UNUSED
+#define TRAINER_PAT                        766
+#define TRAINER_HILLARY                    767
+#define TRAINER_MAY_RUSTBORO_TREECKO       768 // UNUSED
+#define TRAINER_MAY_RUSTBORO_TORCHIC       769 // UNUSED
+#define TRAINER_ROXANNE_2                  770 // UNUSED
+#define TRAINER_ROXANNE_3                  771 // UNUSED
+#define TRAINER_ROXANNE_4                  772 // UNUSED
+#define TRAINER_ROXANNE_5                  773 // UNUSED
+#define TRAINER_DIRK                       774
+#define TRAINER_DON                        775
+#define TRAINER_DORIS                      776
+#define TRAINER_EDNA                       777
+#define TRAINER_ETO_2                      778
+#define TRAINER_ETO_3                      779
+#define TRAINER_WATTSON_4                  780 // UNUSED
+#define TRAINER_WATTSON_5                  781 // UNUSED
+#define TRAINER_QUENTIN                    782
+#define TRAINER_QUINN                      783
+#define TRAINER_RACHAEL                    784 // UNUSED
+#define TRAINER_RALPH                      785
+#define TRAINER_NORMAN_2                   786 // UNUSED
+#define TRAINER_NORMAN_3                   787 // UNUSED
+#define TRAINER_NORMAN_4                   788 // UNUSED
+#define TRAINER_NORMAN_5                   789 // UNUSED
+#define TRAINER_WINONA_2                   790 // UNUSED
+#define TRAINER_WINONA_3                   791 // UNUSED
+#define TRAINER_WINONA_4                   792 // UNUSED
+#define TRAINER_WINONA_5                   793 // UNUSED
+#define TRAINER_TATE_AND_LIZA_2            794 // UNUSED
+#define TRAINER_TATE_AND_LIZA_3            795 // UNUSED
+#define TRAINER_TATE_AND_LIZA_4            796 // UNUSED
+#define TRAINER_TATE_AND_LIZA_5            797 // UNUSED
+#define TRAINER_JUAN_2                     798 // UNUSED
+#define TRAINER_JUAN_3                     799 // UNUSED
+#define TRAINER_JUAN_4                     800 // UNUSED
+#define TRAINER_JUAN_5                     801 // UNUSED
+#define TRAINER_CARLENE                    802 // UNUSED
+#define TRAINER_JIN                        803
+#define TRAINER_STEVEN                     804 // UNUSED
+#define TRAINER_BRET                       805
+#define TRAINER_TUCKER                     806
+#define TRAINER_SPENSER                    807 // UNUSED
+#define TRAINER_SAM                        808
+#define TRAINER_NOLAND                     809
+#define TRAINER_LUCY                       810 // UNUSED
+#define TRAINER_BRANDON                    811
+#define TRAINER_BROOKE                     812
+#define TRAINER_BURT                       813
+#define TRAINER_CALVIN                     814
 #define TRAINER_CAMERON                    815
-#define TRAINER_HAL                      816
-#define TRAINER_HANK                      817
-#define TRAINER_HAROLD                      818
-#define TRAINER_HARRIS                      819
-#define TRAINER_PABLO_2                     820
-#define TRAINER_PABLO_3                     821
-#define TRAINER_PABLO_4                     822
-#define TRAINER_PABLO_5                     823
-#define TRAINER_KOJI_2                      824
-#define TRAINER_KOJI_3                      825
-#define TRAINER_KOJI_4                      826
-#define TRAINER_KOJI_5                      827
-#define TRAINER_HORTON                   828
-#define TRAINER_IAN                   829
-#define TRAINER_IRWIN                   830
-#define TRAINER_ISSAC                   831
-#define TRAINER_OTIS                  832
-#define TRAINER_PARRY                  833
-#define TRAINER_PATON                  834
-#define TRAINER_PETER                  835
-#define TRAINER_SAWYER_2                    836
-#define TRAINER_SAWYER_3                    837
-#define TRAINER_SAWYER_4                    838
-#define TRAINER_SAWYER_5                    839
-#define TRAINER_RON                 840
-#define TRAINER_ROSS                 841
-#define TRAINER_ROXANNE                 842
-#define TRAINER_ROY                 843
-#define TRAINER_THALIA_2                    844
-#define TRAINER_THALIA_3                    845
-#define TRAINER_THALIA_4                    846
-#define TRAINER_THALIA_5                    847
-#define TRAINER_MARIELA                     848
+#define TRAINER_HAL                        816 // UNUSED
+#define TRAINER_HANK                       817
+#define TRAINER_HAROLD                     818
+#define TRAINER_HARRIS                     819
+#define TRAINER_PABLO_2                    820 // UNUSED
+#define TRAINER_PABLO_3                    821 // UNUSED
+#define TRAINER_PABLO_4                    822 // UNUSED
+#define TRAINER_PABLO_5                    823 // UNUSED
+#define TRAINER_KOJI_2                     824 // UNUSED
+#define TRAINER_KOJI_3                     825 // UNUSED
+#define TRAINER_KOJI_4                     826 // UNUSED
+#define TRAINER_KOJI_5                     827 // UNUSED
+#define TRAINER_HORTON                     828
+#define TRAINER_IAN                        829
+#define TRAINER_IRWIN                      830
+#define TRAINER_ISSAC                      831
+#define TRAINER_OTIS                       832
+#define TRAINER_PARRY                      833
+#define TRAINER_PATON                      834 // UNUSED
+#define TRAINER_PETER                      835
+#define TRAINER_SAWYER_2                   836 // UNUSED
+#define TRAINER_SAWYER_3                   837 // UNUSED
+#define TRAINER_SAWYER_4                   838 // UNUSED
+#define TRAINER_SAWYER_5                   839 // UNUSED
+#define TRAINER_RON                        840
+#define TRAINER_ROSS                       841
+#define TRAINER_ROXANNE                    842
+#define TRAINER_ROY                        843
+#define TRAINER_THALIA_2                   844 // UNUSED
+#define TRAINER_THALIA_3                   845 // UNUSED
+#define TRAINER_THALIA_4                   846 /
+#define TRAINER_THALIA_5                   847 // UNUSED
+#define TRAINER_MARIELA                    848 // UNUSED
 #define TRAINER_BORIS                      849
 #define TRAINER_NICOLE                     850
-#define TRAINER_RED                         851
-#define TRAINER_LEAF                        852
-#define TRAINER_BRENDAN_PLACEHOLDER         853
-#define TRAINER_MAY_PLACEHOLDER             854
-#define TRAINER_GRUNT_12                    855 //857
-#define TRAINER_WALLACE2                    856 //858
-#define TRAINER_CHANSEY3                    857 //859
-#define TRAINER_CHANSEY4                    858 //85A
-#define TRAINER_CHANSEY5                    859 //85B
-#define TRAINER_SIDNEY2                     860 //85C
-#define TRAINER_PHOEBE2                     861 //85D
-#define TRAINER_PROTON_1                     862 //85E
-#define TRAINER_KIP2                      863 //85F
+#define TRAINER_RED                        851 // TEST SYSTEM
+#define TRAINER_LEAF                       852 // TEST SYSTEM/ UNUSED
+#define TRAINER_BRENDAN_PLACEHOLDER        853 // UNUSED
+#define TRAINER_MAY_PLACEHOLDER            854 // UNUSED
+#define TRAINER_GRUNT_12                   855 //857
+#define TRAINER_WALLACE2                   856 //858 // UNUSED
+#define TRAINER_CHANSEY3                   857 //859 // UNUSED
+#define TRAINER_CHANSEY4                   858 //85A // UNUSED
+#define TRAINER_CHANSEY5                   859 //85B
+#define TRAINER_SIDNEY2                    860 //85C // UNUSED
+#define TRAINER_PHOEBE2                    861 //85D // UNUSED
+#define TRAINER_PROTON_1                   862 //85E
+#define TRAINER_KIP2                       863 //85F // UNUSED
 
 // NOTE: Because each Trainer uses a flag to determine when they are defeated, there is only space for 9 additional trainers before trainer flag space overflows
 //       More space can be made by shifting flags around in constants/flags.h or changing how trainer flags are handled

--- a/test/battle/form_change/status.c
+++ b/test/battle/form_change/status.c
@@ -3,7 +3,7 @@
 
 SINGLE_BATTLE_TEST("Shaymin-Sky reverts to Shaymin-Land when frozen or frostbitten")
 {
-    KNOWN_FAILING; // This test tosses a coin every time I swear
+    //KNOWN_FAILING; // This test tosses a coin every time I swear
     u32 move;
 
     PARAMETRIZE { move = MOVE_POWDER_SNOW; }


### PR DESCRIPTION
Adds UNUSED comments next to trainers in opponents.h that don't feature in any `data/maps/*_hns/scripts.inc` files. 

Note: check was run by Copilot so (1) take results with a pinch of salt and (2) it's still worth checking trainers aren't used elsewhere such as rematches / avoiding replacing the Emerald version of the trainer etc

## Discord contact info
grintoul