### PR TITLE
Shaymin Sky test fixed by forcing DAY hour in test

### DIFF
--- a/test/battle/form_change/status.c
+++ b/test/battle/form_change/status.c
@@ -1,9 +1,9 @@
 #include "global.h"
+#include "overworld.h"
 #include "test/battle.h"
 
 SINGLE_BATTLE_TEST("Shaymin-Sky reverts to Shaymin-Land when frozen or frostbitten")
 {
-    //KNOWN_FAILING; // This test tosses a coin every time I swear
     u32 move;
 
     PARAMETRIZE { move = MOVE_POWDER_SNOW; }
@@ -13,6 +13,7 @@ SINGLE_BATTLE_TEST("Shaymin-Sky reverts to Shaymin-Land when frozen or frostbitt
     PARAMETRIZE { move = MOVE_POISON_FANG; }
 
     GIVEN {
+        SetTimeOfDay(12); // Force time around midday to prevent local time causing test to fail outside of DAY hours
         ASSUME(MoveHasAdditionalEffect(MOVE_POWDER_SNOW, MOVE_EFFECT_FREEZE_OR_FROSTBITE));
         ASSUME(MoveHasAdditionalEffect(MOVE_EMBER, MOVE_EFFECT_BURN));
         ASSUME(MoveHasAdditionalEffect(MOVE_THUNDERSHOCK, MOVE_EFFECT_PARALYSIS));


### PR DESCRIPTION
## Description
Fixed temperamental Shaymin Sky test by forcing time hour to 12 to set DAY. Issue was that local time was somehow impacting test causing Shaymin to be sent out in regular form if local PC time is at a non-DAY hour.

## Discord contact info
grintoul